### PR TITLE
added valueerror to layer function

### DIFF
--- a/vde/vde.py
+++ b/vde/vde.py
@@ -34,6 +34,8 @@ def Layer(i, o, activation=None, p=0., bias=True):
         model += [nn.Tanh()]
     elif activation == 'Swish':
         model += [Swish()]
+    elif type(activation) is str:
+        raise ValueError('{} activation not implemented.'.format(activation))
 
     if p > 0.:
         model += [nn.Dropout(p)]


### PR DESCRIPTION
I think the design of the `Layer` function is a bit dangerous. If it doesn't recognize the activation string, it just outputs a linear model. This is especially scary given that it only recognizes `RELU` and not `ReLU`, where the latter has the pytorch case convention.

I've just added a simple error here that if the activation is a string but not in the list, at least the user knows about it. A nice option might be to make everything case insensitive.